### PR TITLE
fixed this module based on observations in my system (64 bits, multiple events per read)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,19 +35,56 @@ function InputEvent(device, options){
   this.fd = fs.createReadStream(this.device, this.options);
   this.fd.on('data', function(data){
     self.emit('raw', data);
-    var ev = self.parse(data);
-    if(ev) self.emit('data', ev, data);
+    self.process(data);
   });
 }
 /**
  * [inherits EventEmitter]
  */
 util.inherits(InputEvent, events.EventEmitter);
+
 /**
- * [function parse]
+ * [function process]
  */
+InputEvent.prototype.process = function(buf){
+  var ev;
+
+  /**
+   * Sometimes (modern Linux), multiple key events will be in the triggered at once for the same timestamp.
+   * The first 4 bytes will be repeated for every event, so we use that knowledge to actually split it.
+   * We assume event structures of 3 bytes, 8 bytes, 16 bytes or 24 bytes.
+   */
+  if (buf.length > 8) {
+    var t = buf.readUInt32LE(0);
+    var lastPos = 0;
+    for (var i = 8, n = buf.length; i < n; i += 8) {
+      if (buf.readUInt32LE(i) === t) {
+        var part = buf.slice(lastPos, i);
+        ev = this.parse(part);
+        if(ev) this.emit('data', ev, part);
+        lastPos = i;
+      }
+    }
+    var part = buf.slice(lastPos, i);
+    ev = this.parse(part);
+    if(ev) this.emit('data', ev, part);
+  } else {
+    ev = this.parse(buf);
+    if(ev) this.emit('data', ev, buf);
+  }
+};
+
 InputEvent.prototype.parse = function(buf){
-  if(buf.length >= 16){
+  if(buf.length >= 24){
+    // unsigned long time structure.
+    return {
+      tssec:   buf.readUInt32LE(0),
+      tsusec:  buf.readUInt32LE(8),
+      type:    buf.readUInt16LE(16),
+      code:    buf.readUInt16LE(18),
+      value:   buf.readUInt32LE(20)
+    };
+  }if(buf.length >= 16){
     // https://www.kernel.org/doc/Documentation/input/input.txt
     // struct input_event {
     // 	struct timeval time;
@@ -56,35 +93,36 @@ InputEvent.prototype.parse = function(buf){
     // 	unsigned int value;
     // };
     return {
-      tssec:   buf.readUInt32LE(0),
-      tsusec:  buf.readUInt32LE(4),
-      type:    buf.readUInt16LE(8),
-      code:    buf.readUInt16LE(10),
-      value:   buf.readUInt32LE(12)
+        tssec:   buf.readUInt32LE(0),
+        tsusec:  buf.readUInt32LE(4),
+        type:    buf.readUInt16LE(8),
+        code:    buf.readUInt16LE(10),
+        value:   buf.readUInt32LE(12)
     };
   }else if(buf.length == 8){
     // https://www.kernel.org/doc/Documentation/input/joystick-api.txt
     // struct js_event {
-  	// 	__u32 time;     /* event timestamp in milliseconds */
-  	// 	__s16 value;    /* value */
-  	// 	__u8 type;      /* event type */
-  	// 	__u8 number;    /* axis/button number */
-  	// };
+    // 	__u32 time;     /* event timestamp in milliseconds */
+    // 	__s16 value;    /* value */
+    // 	__u8 type;      /* event type */
+    // 	__u8 number;    /* axis/button number */
+    // };
     return {
-      time  : buf.readUInt32LE(0),
-      value : buf.readInt16LE(4),
-      type  : buf.readUInt8(6),
-      number: buf.readUInt8(7)
+        time  : buf.readUInt32LE(0),
+        value : buf.readInt16LE(4),
+        type  : buf.readUInt8(6),
+        number: buf.readUInt8(7)
     };
   }else if(buf.length == 3){
     // mice mouse
     return {
-      t : buf.readInt8(0),
-      x : buf.readInt8(1),
-      y : buf.readInt8(2)
+        t : buf.readInt8(0),
+        x : buf.readInt8(1),
+        y : buf.readInt8(2)
     };
   }
 };
+
 /**
  * [function close]
  * @param  {Function} callback [description]

--- a/test/test.js
+++ b/test/test.js
@@ -1,25 +1,25 @@
 var InputEvent = require('../');
 
-// var input = new InputEvent('/dev/input/event0');
-var input = new InputEvent('/dev/input/mice');
+var input = new InputEvent('/dev/input/event6');
+//var input = new InputEvent('/dev/input/mice');
 //
 // input.on('data', function(buffer){
 //   console.log(buffer);
 // });
 
-// var keyboard = new InputEvent.Keyboard(input);
+var keyboard = new InputEvent.Keyboard(input);
 // keyboard.on('data'    , console.log);
-// keyboard.on('keyup'   , console.log);
-// keyboard.on('keydown' , console.log);
+keyboard.on('keyup'   , console.log);
+keyboard.on('keydown' , console.log);
 // keyboard.on('keypress', console.log);
 
-var mouse = new InputEvent.Mouse(input);
+//var mouse = new InputEvent.Mouse(input);
 // mouse.on('data'    , console.log);
 // mouse.on('move'    , console.log);
 // mouse.on('wheel'   , console.log);
 // mouse.on('keyup'   , console.log);
 // mouse.on('keydown' , console.log);
-mouse.on('keypress', console.log);
+//mouse.on('keypress', console.log);
 
 
 // var joystick = new InputEvent.JoyStick(input);


### PR DESCRIPTION
Sometimes (modern Linux), multiple key events will be in the triggered at once for the same timestamp. Also, my 64 bit Linux system uses time structures that consist of two unsigned longs (instead of 2 unsigned ints).
The first 4 bytes will be repeated for every event, so we use that knowledge to actually split it.