### PR TITLE
Allow handling of disconnected/failing devices

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,9 @@ function InputEvent(device, options){
     self.emit('raw', data);
     self.process(data);
   });
+  this.fd.on('error', function(err){
+    self.emit('error', err);
+  });
 }
 /**
  * [inherits EventEmitter]


### PR DESCRIPTION
When input devices failing / are disconnected  fd thows an error event which was not handled and lead to crashes