### PR TITLE
armv6l workaround

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,8 @@ function InputEvent(device, options){
   }
   this.device  = device;
   this.options = options || { flags: 'r', encoding: null };
-  this.fd = fs.createReadStream(this.device, this.options);
+  this.options.fd = fs.openSync(this.device, this.options.flags);
+  this.fd = fs.createReadStream(null, this.options);
   this.fd.on('data', function(data){
     self.emit('raw', data);
     self.process(data);


### PR DESCRIPTION
Using `fs.createReadStream()` with a path of an input device will throw the follow error in **Raspberry Pi Zero W**, **Raspbian Lite (stretch)**, **node.js v9.5.0**.

```
events.js:137
      throw er; // Unhandled 'error' event
      ^

Error: ESPIPE: invalid seek, read
```

According to the doc, using the `options.fd` will skip the initial `seek` command when `options.start` is `undefined`.

I tested this change in my Raspberry Pi and Macbook.