### PR TITLE
Replace "error" event to "disconnect"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ function InputEvent(device, options){
     self.process(data);
   });
   this.fd.on('error', function(err){
-    self.emit('error', err);
+    self.emit('disconnect', err);
   });
 }
 /**


### PR DESCRIPTION
When an input device is removed, the keyboard.on('error') handler is not always called, and even when it is, node crashes with an 'Unhandled error event' exception:
```
        input = new InputEvent(options.barcodeScannerPath);
        keyboard = new InputEvent.Keyboard(input);
        keyboard.on('keyup', processKeyEvent);    
        keyboard.on('keypress', processKeyEvent);    
        keyboard.on('keydown', processKeyEvent); 
        keyboard.on('error', processErrorEvent);

....

function processErrorEvent(error) {
  console.log('Error Event', error);
}

```


On disconnection of the input device, the following is printed, then node exits:

```
Error Event { Error: ENODEV: no such device, read errno: -19, code: 'ENODEV', syscall: 'read' }
events.js:183
      throw er; // Unhandled 'error' event
      ^

Error: ENODEV: no such device, read
```

Changing the name of the event emitted from 'error' to 'disconnect' allows me to handle the disconnection event without node crashing.